### PR TITLE
hotfix: removed admission number input field

### DIFF
--- a/src/pages/auth/signUp/SignUpPage.tsx
+++ b/src/pages/auth/signUp/SignUpPage.tsx
@@ -39,6 +39,7 @@ const SignUpPage: React.FC = observer(() => {
   const password = watch('password');
   const onSubmit = async (body: User.CreateDto) => {
     body.profileImage = null;
+    body.admissionYear = +body.studentId.slice(0, 4);
     const { success, message } = (await signUp(body)) as unknown as StoreAPI;
 
     if (success) {
@@ -130,29 +131,6 @@ const SignUpPage: React.FC = observer(() => {
           {errors.name ? <ErrorMessage>{errors.name?.message}</ErrorMessage> : null}
 
           <Input
-            name="admissionYear"
-            type="number"
-            label="입학년도"
-            placeholder="입학년도 4자리를 입력하세요. (ex.2020)"
-            required
-            control={control}
-            rules={{
-              required: '입학년도를 입력해주세요.',
-              minLength: {
-                value: 4,
-                message: '4자리 입학년도를 입력해주세요.',
-              },
-              maxLength: {
-                value: 4,
-                message: '4자리 입학년도를 입력해주세요.',
-              },
-            }}
-          />
-          {errors.admissionYear ? (
-            <ErrorMessage>{errors.admissionYear?.message}</ErrorMessage>
-          ) : null}
-
-          <Input
             name="studentId"
             type="number"
             label="학번"
@@ -163,11 +141,11 @@ const SignUpPage: React.FC = observer(() => {
               required: '학번을 입력해주세요.',
               minLength: {
                 value: 8,
-                message: '8자리 입학년도를 입력해주세요.',
+                message: '8자리 학번을 입력해주세요.',
               },
               maxLength: {
                 value: 8,
-                message: '8자리 입학년도를 입력해주세요.',
+                message: '8자리 학번을 입력해주세요.',
               },
             }}
           />


### PR DESCRIPTION
make admission year with studentId

🚩 관련 이슈
resolve #113 

📋 PR Checklist

- 입학년도 input field 제거
- admissionYear는 studentId로 계산
-  + 학번 입력에서 오류 메세지가 입학년도로 되어 있어 학번으로 바꿈

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
![image](https://github.com/CAUCSE/CAUSW_frontend/assets/54625012/8aadb673-9e90-48d1-ba4d-88f1df489989)
